### PR TITLE
fix: prevent race condition on sensitive routes

### DIFF
--- a/server/src/controllers/Brutes.ts
+++ b/server/src/controllers/Brutes.ts
@@ -41,6 +41,7 @@ import sendError from '../utils/sendError.js';
 import translate from '../utils/translate.js';
 import { increaseAchievement } from './Achievements.js';
 import { LOGGER } from '../context.js';
+import { lock, unlock } from '../utils/lock.js';
 
 const Brutes = {
   getForVersus: (prisma: PrismaClient) => async (
@@ -185,6 +186,7 @@ const Brutes = {
   ) => {
     try {
       const user = await auth(prisma, req);
+      lock(user);
 
       // Check name length
       if (!isNameValid(req.body.name)) {
@@ -311,6 +313,8 @@ const Brutes = {
       await checkLevelUpAchievements(prisma, brute, destinyChoice);
 
       res.send({ brute, goldLost, newLimit });
+
+      unlock(user);
     } catch (error) {
       sendError(res, error);
     }
@@ -318,6 +322,7 @@ const Brutes = {
   getLevelUpChoices: (prisma: PrismaClient) => async (req: Request, res: Response) => {
     try {
       const user = await auth(prisma, req);
+      lock(user);
 
       // Get brute
       const brute = user.brutes.find((b) => b.name === req.params.name);
@@ -383,6 +388,7 @@ const Brutes = {
   ) => {
     try {
       const user = await auth(prisma, req);
+      lock(user);
 
       // Get brute
       const brute = user.brutes.find((b) => b.name === req.params.name);
@@ -439,10 +445,6 @@ const Brutes = {
 
       if (!freshBrute) {
         throw new Error(translate('bruteNotFound', user));
-      }
-
-      if (freshBrute.xp !== brute.xp) {
-        throw new ExpectedError(translate('slowDown', user));
       }
 
       // Update brute
@@ -509,6 +511,7 @@ const Brutes = {
       }
 
       res.send(updatedBrute);
+      unlock(user);
     } catch (error) {
       sendError(res, error);
     }
@@ -911,6 +914,7 @@ const Brutes = {
       const { params: { name } } = req;
 
       const user = await auth(prisma, req);
+      lock(user);
 
       if (!name) {
         throw new Error(translate('missingName', user));
@@ -1114,6 +1118,7 @@ const Brutes = {
       res.send({
         success: true,
       });
+      unlock(user);
     } catch (error) {
       sendError(res, error);
     }

--- a/server/src/controllers/Fights.ts
+++ b/server/src/controllers/Fights.ts
@@ -8,6 +8,7 @@ import getOpponents from '../utils/brute/getOpponents.js';
 import generateFight from '../utils/fight/generateFight.js';
 import sendError from '../utils/sendError.js';
 import translate from '../utils/translate.js';
+import { lock, unlock } from '../utils/lock.js';
 
 const Fights = {
   get: (prisma: PrismaClient) => async (req: Request, res: Response) => {
@@ -64,6 +65,7 @@ const Fights = {
   ) => {
     try {
       const user = await auth(prisma, req);
+      lock(user);
 
       if (!req.body.brute1 || !req.body.brute2) {
         throw new ExpectedError(translate('missingParameters', user));
@@ -235,6 +237,8 @@ const Fights = {
 
       // Send fight id to client
       res.send({ id: fightId });
+
+      unlock(user);
     } catch (error) {
       sendError(res, error);
     }

--- a/server/src/utils/lock.ts
+++ b/server/src/utils/lock.ts
@@ -1,0 +1,30 @@
+import { ExpectedError } from '@labrute/core';
+import { User } from '@labrute/prisma';
+import translate from './translate.js';
+
+interface Lock {
+  userId: string;
+  timer: NodeJS.Timeout;
+}
+
+let locked: Lock[] = [];
+
+export const unlock = (user: User) => {
+  const existingLock = locked.find((l) => l.userId === user.id);
+  if (existingLock) {
+    clearTimeout(existingLock.timer);
+    locked = locked.filter((l) => l.userId !== user.id);
+  }
+};
+
+export const lock = (user: User) => {
+  if (locked.some((l) => l.userId === user.id)) throw new ExpectedError(translate('slowDown', user));
+  const timeout = setInterval(() => {
+    unlock(user);
+  }, 5000);
+  const newLock: Lock = {
+    timer: timeout,
+    userId: user.id,
+  };
+  locked.push(newLock);
+};


### PR DESCRIPTION
I've added a lock, to prevent user to call sensitives routes multiple times.

There is usually not a lot of good ways to prevent this kind of vulnerabilities, and this is probably not the cleanest way to do it, but it works