### PR TITLE
Wrong clan points recalculation on brute reset

### DIFF
--- a/server/src/controllers/Brutes.ts
+++ b/server/src/controllers/Brutes.ts
@@ -1527,7 +1527,7 @@ const Brutes = {
 
       // Update clan points
       if (brute.clanId) {
-        await updateClanPoints(prisma, brute.clanId, 'add', brute, updatedBrute);
+        await updateClanPoints(prisma, brute.clanId, 'add', updatedBrute, brute);
       }
 
       res.send(updatedBrute);


### PR DESCRIPTION
Fixes #983
Switched `brute` and `updatedBrute` to fix wrong clan point recalculation.