### PR TITLE
Fix tournament cell logs

### DIFF
--- a/client/src/components/Cell/CellLog.tsx
+++ b/client/src/components/Cell/CellLog.tsx
@@ -93,7 +93,9 @@ const CellLog = ({ log, sx, ...rest }: CellLogProps) => {
                   ? t('log.up', { brute: log.currentBrute.name, value: log.level ?? 0 })
                   : log.type === LogType.ascend
                     ? t(log.level && log.level > 1 ? 'log.ascends' : 'log.ascend', { brute: log.currentBrute.name, value: log.level ?? 0 })
-                    : t('log.tournament', { date: moment.utc(log.date).format('DD/MM/YY') })}
+                    : log.type === LogType.tournament
+                      ? t('log.tournament', { date: moment.utc(log.date).format('DD/MM/YY') })
+                      : t(`log.${log.type}`, { value: log.brute })}
             </Text>
           )}
         {(!!log.xp || !!log.gold) && (


### PR DESCRIPTION
Correctly display the log.tournamentXp text instead of the log.tournament