### PR TITLE
feat(TournamentView): add podium beneath winner

### DIFF
--- a/client/src/views/TournamentView.tsx
+++ b/client/src/views/TournamentView.tsx
@@ -384,32 +384,47 @@ const TournamentView = () => {
             && (!authing && brute)
             && (!ownsBrute || (ownsBrute && stepWatched > 5))
             && (
-              <BruteTooltip
-                fighter={winnerFight.winner === winnerFight.brute1.name
-                  ? winnerStepFighters
-                    .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute1.name)
-                  : winnerStepFighters
-                    .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute2?.name)}
-                brute={winnerFight.winner === winnerFight.brute1.name
-                  ? winnerFight.brute1
-                  : winnerFight.brute2}
+              <Box sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                position: 'absolute',
+                bottom: 0,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              }}
               >
-                <BruteRender
+                <BruteTooltip
+                  fighter={winnerFight.winner === winnerFight.brute1.name
+                    ? winnerStepFighters
+                      .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute1.name)
+                    : winnerStepFighters
+                      .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute2?.name)}
                   brute={winnerFight.winner === winnerFight.brute1.name
                     ? winnerFight.brute1
-                    : winnerFight?.brute2}
+                    : winnerFight.brute2}
+                >
+                  <BruteRender
+                    brute={winnerFight.winner === winnerFight.brute1.name
+                      ? winnerFight.brute1
+                      : winnerFight?.brute2}
+                    sx={{
+                      height: '175px',
+                      width: 'auto',
+                      left: 0,
+                    }}
+                  />
+                </BruteTooltip>
+                <Box
+                  component="img"
+                  src="/images/tournament/podium.svg"
                   sx={{
-                    position: 'absolute',
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
-                    mx: 'auto',
-                    top: 'initial',
-                    width: 100,
-                    transformOrigin: 'bottom center',
+                    width: 135,
+                    marginTop: '-40px',
+                    marginLeft: '15px',
                   }}
                 />
-              </BruteTooltip>
+              </Box>
             )}
         </Paper>
       </Page>

--- a/client/src/views/mobile/TournamentMobileView.tsx
+++ b/client/src/views/mobile/TournamentMobileView.tsx
@@ -229,25 +229,45 @@ const TournamentMobileView = ({
           && (!authing && brute)
           && (!ownsBrute || (ownsBrute && stepWatched > 5))
           && (
-            <BruteTooltip
-              fighter={winnerFight.winner === winnerFight.brute1.name
-                ? winnerFightFighters
-                  .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute1.name)
-                : winnerFightFighters
-                  .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute2?.name)}
-              brute={winnerFight.winner === winnerFight.brute1.name
-                ? winnerFight.brute1
-                : winnerFight.brute2}
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
             >
-              <Box width={100} mx="auto">
-                <BruteRender
-                  brute={winnerFight.winner === winnerFight.brute1.name
-                    ? winnerFight.brute1
-                    : winnerFight?.brute2}
-                  width={100}
-                />
-              </Box>
-            </BruteTooltip>
+              <BruteTooltip
+                fighter={winnerFight.winner === winnerFight.brute1.name
+                  ? winnerFightFighters
+                    .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute1.name)
+                  : winnerFightFighters
+                    .find((fighter) => fighter.type === 'brute' && fighter.name === winnerFight.brute2?.name)}
+                brute={winnerFight.winner === winnerFight.brute1.name
+                  ? winnerFight.brute1
+                  : winnerFight.brute2}
+              >
+                <Box width={100} mx="auto">
+                  <BruteRender
+                    brute={winnerFight.winner === winnerFight.brute1.name
+                      ? winnerFight.brute1
+                      : winnerFight?.brute2}
+                    width={100}
+                    sx={{
+                      width: '100%',
+                      left: 0,
+                    }}
+                  />
+                </Box>
+              </BruteTooltip>
+              <Box
+                component="img"
+                src="/images/tournament/podium.svg"
+                sx={{
+                  width: 155,
+                  marginTop: '-55px',
+                  marginLeft: '20px',
+                }}
+              />
+            </Box>
           )}
 
       </Paper>


### PR DESCRIPTION
Added the podium beneath the winner on both Desktop and Mobile view. See some screenshot on how it renders. 

<img width="675" alt="Screenshot 2024-12-07 at 16 10 04" src="https://github.com/user-attachments/assets/552f733d-03cc-4d86-9b5a-4aa397bbb408">
<img width="928" alt="Screenshot 2024-12-07 at 16 09 58" src="https://github.com/user-attachments/assets/db959a37-e477-4f2d-b2e7-53c046c2af36">
