### PR TITLE
feat: add loader state for buttons and use it for API CTA

### DIFF
--- a/client/src/components/Cell/CellMain.tsx
+++ b/client/src/components/Cell/CellMain.tsx
@@ -2,7 +2,7 @@ import { BruteRanking, getFightsLeft, getMaxFightsPerDay, getWinsNeededToRankUp,
 import { Lang } from '@labrute/prisma';
 import { AlertTitle, Box, BoxProps, Alert as MuiAlert, Stack, Tooltip } from '@mui/material';
 import moment from 'moment';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAlert } from '../../hooks/useAlert';
 import { useAuth } from '../../hooks/useAuth';
@@ -39,6 +39,7 @@ const CellMain = ({
   const Alert = useAlert();
   const { brute, owner } = useBrute();
   const { user, authing, currentEvent, modifiers } = useAuth();
+  const [isLoading, setIsLoading] = useState(false);
 
   const xpNeededForNextLevel = useMemo(
     () => (brute ? getXPNeeded(brute.level + 1) : 0),
@@ -64,9 +65,11 @@ const CellMain = ({
 
   // Login
   const login = useCallback(() => {
+    setIsLoading(true);
     Fetch<{ url: string }>('/api/oauth/redirect').then(({ url }) => {
       window.location.href = url;
-    }).catch(catchError(Alert));
+    }).catch(catchError(Alert))
+      .finally(() => setIsLoading(false));
   }, [Alert]);
 
   return brute && (
@@ -158,6 +161,7 @@ const CellMain = ({
         <FantasyButton
           color="success"
           onClick={login}
+          loading={isLoading}
           sx={{ mt: 2 }}
         >
           {t('connect')}

--- a/client/src/components/Cell/CellTournament.tsx
+++ b/client/src/components/Cell/CellTournament.tsx
@@ -1,7 +1,7 @@
 import { Lang } from '@labrute/prisma';
 import { Box, Paper, PaperProps } from '@mui/material';
 import moment from 'moment';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAlert } from '../../hooks/useAlert';
 import { useAuth } from '../../hooks/useAuth';
@@ -25,12 +25,14 @@ const CellTournament = ({
   const Alert = useAlert();
   const { brute, owner, updateBrute } = useBrute();
   const { updateData } = useAuth();
+  const [isRegisteringBrute, setIsRegisteringBrute] = useState(false);
 
   const now = useMemo(() => moment.utc(), []);
   const tomorrow = useMemo(() => moment.utc().add(1, 'day'), []);
 
   const registerBrute = useCallback(() => {
     if (!brute) return;
+    setIsRegisteringBrute(true);
     Server.Tournament.registerDaily(brute?.name || '').then(() => {
       Alert.open('success', t('bruteRegistered'));
 
@@ -50,7 +52,8 @@ const CellTournament = ({
           return b;
         }),
       }) : data));
-    }).catch(catchError(Alert));
+    }).catch(catchError(Alert))
+      .finally(() => setIsRegisteringBrute(false));
   }, [Alert, brute, t, updateBrute, updateData]);
 
   return brute && (
@@ -99,6 +102,7 @@ const CellTournament = ({
                 shadow={false}
                 contrast={false}
                 onClick={registerBrute}
+                disabled={isRegisteringBrute}
               />
             )}
           </Paper>

--- a/client/src/components/FantasyButton.tsx
+++ b/client/src/components/FantasyButton.tsx
@@ -2,6 +2,7 @@ import { adjustColor } from '@labrute/core';
 import { Box, BoxProps, useTheme } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router';
+import Loader from './Loader';
 
 interface FantasyButtonProps extends BoxProps {
   color: 'primary'
@@ -13,11 +14,13 @@ interface FantasyButtonProps extends BoxProps {
   disabled?: boolean;
   to?: string;
   size?: 'normal' | 'large';
+  loading?: boolean;
 }
 
 /**
  * FantasyButton component
  */
+
 const FantasyButton = React.forwardRef<HTMLDivElement, FantasyButtonProps>(({
   children,
   color = 'primary',
@@ -25,6 +28,7 @@ const FantasyButton = React.forwardRef<HTMLDivElement, FantasyButtonProps>(({
   sx,
   to,
   size = 'normal',
+  loading = false,
   ...rest
 }: FantasyButtonProps, ref) => {
   const theme = useTheme();
@@ -34,8 +38,11 @@ const FantasyButton = React.forwardRef<HTMLDivElement, FantasyButtonProps>(({
   const colorDark = adjustColor(COLOR, -30);
   const colorDarker = adjustColor(COLOR, -60);
 
+  const loaderSize = size === 'large' ? 20 : 16;
+  const isButtonDisabled = disabled || loading;
+
   const handleClick = () => {
-    if (!disabled && to) {
+    if (!isButtonDisabled && to) {
       navigate(to);
     }
   };
@@ -59,7 +66,7 @@ const FantasyButton = React.forwardRef<HTMLDivElement, FantasyButtonProps>(({
         color: theme.palette[color].contrastText,
         py: size === 'normal' ? 0.5 : 1,
         px: size === 'normal' ? 1 : 2,
-        cursor: disabled ? 'not-allowed' : 'pointer',
+        cursor: isButtonDisabled ? 'not-allowed' : 'pointer',
         textTransform: 'uppercase',
         typography: 'LaBrute',
         fontSize: '1rem',
@@ -93,7 +100,14 @@ const FantasyButton = React.forwardRef<HTMLDivElement, FantasyButtonProps>(({
       }}
       {...rest}
     >
-      {children}
+      {loading && (
+        <Box sx={{ position: 'absolute', left: '50%', top: '50%', transform: 'translate(-50%, -50%)' }}>
+          <Loader size={loaderSize} color="inherit" />
+        </Box>
+      )}
+      <Box sx={{ visibility: loading ? 'hidden' : 'initial', }}>
+        {children}
+      </Box>
     </Box>
   );
 });

--- a/client/src/components/StyledButton.tsx
+++ b/client/src/components/StyledButton.tsx
@@ -1,6 +1,7 @@
 import { Box, BoxProps, useTheme } from '@mui/material';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router';
+import Loader from './Loader';
 
 export interface StyledButtonProps extends Omit<BoxProps, 'translate'> {
   image?: string;
@@ -12,6 +13,8 @@ export interface StyledButtonProps extends Omit<BoxProps, 'translate'> {
   shiftMargin?: boolean;
   shadowColor?: string;
   to?: string;
+  disabled?: boolean;
+  loading?: boolean;
 }
 
 export const StyledButtonWidth = 207;
@@ -32,6 +35,8 @@ const StyledButton = React.forwardRef<HTMLDivElement, StyledButtonProps>(({
   shadowColor = 'rgba(0, 0, 0, 0.2)',
   to,
   sx,
+  disabled = false,
+  loading = false,
   ...rest
 }: StyledButtonProps, ref) => {
   const { palette: { mode } } = useTheme();
@@ -39,6 +44,8 @@ const StyledButton = React.forwardRef<HTMLDivElement, StyledButtonProps>(({
 
   const themedImage = mode === 'dark' ? image.replace('/images/', '/images/dark/') : image;
   const themedImageHover = mode === 'dark' ? imageHover.replace('/images/', '/images/dark/') : imageHover;
+
+  const isButtonDisabled = disabled || loading;
 
   // Controlled hover state
   const [hover, setHover] = React.useState(false);
@@ -51,7 +58,7 @@ const StyledButton = React.forwardRef<HTMLDivElement, StyledButtonProps>(({
   }, []);
 
   const handleClick = () => {
-    if (to) {
+    if (to && !isButtonDisabled) {
       navigate(to);
     }
   };
@@ -73,7 +80,7 @@ const StyledButton = React.forwardRef<HTMLDivElement, StyledButtonProps>(({
         height: StyledButtonHeight,
         pt: hover ? 0 : shift,
         pb: shift,
-        cursor: 'pointer',
+        cursor: isButtonDisabled ? 'not-allowed' : 'pointer',
         backgroundImage: `url('${swapImage ? hover ? themedImageHover : themedImage : themedImage}')`,
         backgroundRepeat: 'no-repeat',
         backgroundSize: '100%',
@@ -81,12 +88,20 @@ const StyledButton = React.forwardRef<HTMLDivElement, StyledButtonProps>(({
         fontVariant: 'small-caps',
         fontWeight: 'bold',
         color: 'secondary.main',
+        position: 'relative',
         ...sx,
         mb: (hover && shiftMargin) ? 1 : undefined,
       }}
       {...rest}
     >
-      {children}
+      {loading && (
+        <Box sx={{ position: 'absolute', left: '50%', top: '50%', transform: 'translate(-50%, -50%)' }}>
+          <Loader size={16} color="inherit" />
+        </Box>
+      )}
+      <Box sx={{ visibility: loading ? 'hidden' : 'initial', }}>
+        {children}
+      </Box>
     </Box>
   );
 });

--- a/client/src/views/AscendView.tsx
+++ b/client/src/views/AscendView.tsx
@@ -30,26 +30,19 @@ const AscendView = () => {
   const Alert = useAlert();
   const isMd = useMediaQuery(theme.breakpoints.down('md'));
 
+  const [isLoading, setIsLoading] = useState(false);
   const [selectedPerk, setSelectedPerk] = useState<WeaponName | SkillName | PetName | null>(null);
 
   const [selectedPerkType, setSelectedPerkType] = useState<'weapon' | 'skill'| 'pet' | null>(null);
 
   // Check if redirect
   useEffect(() => {
-    let redirect = false;
-
     if (!brute) {
       navigate('/');
       return;
     }
 
-    if (!brute.canRankUpSince) {
-      redirect = true;
-    } else if (brute.ranking !== 0) {
-      redirect = true;
-    }
-
-    if (redirect) {
+    if (!brute.canRankUpSince || brute.ranking !== 0) {
       navigate(`/${brute.name}/cell`);
     }
   }, [brute, navigate]);
@@ -167,12 +160,14 @@ const AscendView = () => {
     }
 
     Confirm.open(t('ascendConfirmShort'), `${t('ascendConfirm')} ${getAscendWithLabel()}`, () => {
+      setIsLoading(true);
       Server.Brute.ascend(brute.name, { [selectedPerkType]: selectedPerk })
         .then(() => {
           goToCell(brute.name)();
           window.location.reload();
         })
-        .catch(catchError(Alert));
+        .catch(catchError(Alert))
+        .finally(() => setIsLoading(false));
     });
   }, [Alert, Confirm, brute, getAscendWithLabel, goToCell, selectedPerk, selectedPerkType, t]);
 
@@ -238,7 +233,13 @@ const AscendView = () => {
               )}
             </Box>
             <Box sx={{ width: 315, display: 'flex', alignItems: 'center', flexWrap: 'wrap', justifyContent: 'center', mt: 1 }}>
-              <FantasyButton color="warning" onClick={ascend} sx={{ mb: 1 }} disabled={!selectedPerk || !selectedPerkType}>
+              <FantasyButton
+                loading={isLoading}
+                color="warning"
+                onClick={ascend}
+                sx={{ mb: 1 }}
+                disabled={!selectedPerk || !selectedPerkType}
+              >
                 {t('ascend')}
               </FantasyButton>
             </Box>

--- a/client/src/views/LevelUpView.tsx
+++ b/client/src/views/LevelUpView.tsx
@@ -32,7 +32,7 @@ const LevelUpView = () => {
   const theme = useTheme();
 
   const [choices, setChoices] = useState<BrutesGetLevelUpChoicesResponse['choices'] | null>(null);
-
+  const [isLevellingUp, setIsLevellingUp] = useState(false);
   const samePath = brute?.previousDestinyPath.toString().startsWith(brute?.destinyPath.toString());
 
   // Fetch brute
@@ -59,10 +59,11 @@ const LevelUpView = () => {
   const levelUp = useCallback((choice: DestinyChoiceSide) => async () => {
     if (!brute || !choices) return;
 
+    setIsLevellingUp(true);
     const newBrute = await Server.Brute.levelUp(
       brute.name,
       choice,
-    ).catch(catchError(Alert));
+    ).catch(catchError(Alert)).finally(() => setIsLevellingUp(false));
 
     if (!newBrute) return;
 
@@ -272,6 +273,7 @@ const LevelUpView = () => {
                   shadow={false}
                   contrast={false}
                   onClick={levelUp(i === 0 ? DestinyChoiceSide.LEFT : DestinyChoiceSide.RIGHT)}
+                  loading={isLevellingUp}
                 >
                   <Text bold smallCaps color="success">{t('validate')}</Text>
                 </StyledButton>

--- a/client/src/views/NameChangeView.tsx
+++ b/client/src/views/NameChangeView.tsx
@@ -17,6 +17,7 @@ const NameChangeView = () => {
   const { brute, owner } = useBrute();
   const Confirm = useConfirm();
 
+  const [isLoading, setIsLoading] = useState(false);
   const [name, setName] = useState('');
 
   // Change name
@@ -24,10 +25,12 @@ const NameChangeView = () => {
     if (!brute) return;
 
     Confirm.open(t('inventory.item.nameChange'), t('nameChangeConfirm', { name }), () => {
+      setIsLoading(true);
       Server.Brute.changeName(brute.name, name).then(() => {
         // Go to new cell
         window.location.href = `/${name}/cell`;
-      }).catch(catchError(Alert));
+      }).catch(catchError(Alert))
+        .finally(() => setIsLoading(false));
     });
   };
 
@@ -60,7 +63,12 @@ const NameChangeView = () => {
             />
             {/* VALIDATION */}
             <Box sx={{ textAlign: 'center' }}>
-              <FantasyButton color="success" onClick={changeName}>{t('validate')}</FantasyButton>
+              <FantasyButton
+                color="success"
+                loading={isLoading}
+                onClick={changeName}
+              >{t('validate')}
+              </FantasyButton>
             </Box>
           </Box>
         )}

--- a/client/src/views/ResetVisualsView.tsx
+++ b/client/src/views/ResetVisualsView.tsx
@@ -25,6 +25,7 @@ const ResetVisualsView = () => {
   const Confirm = useConfirm();
   const { resetCache } = useRenderer();
 
+  const [isLoading, setIsLoading] = useState(false);
   const [body, setBody] = useState<string | null>(
     null
   );
@@ -61,6 +62,7 @@ const ResetVisualsView = () => {
 
     Confirm.open(t('resetVisuals'), t('resetVisualsConfirm'), () => {
       // Update brute visuals
+      setIsLoading(true);
       Server.Brute.resetVisuals(brute.name, body, colors).then(() => {
         Alert.open('success', t('resetVisualsSuccess'));
 
@@ -87,7 +89,8 @@ const ResetVisualsView = () => {
         // Go to cell
         navigate(`/${brute.name}/cell`);
       })
-        .catch(catchError(Alert));
+        .catch(catchError(Alert))
+        .finally(() => setIsLoading(false));
     });
   };
 
@@ -156,7 +159,12 @@ const ResetVisualsView = () => {
             </Box>
             {/* VALIDATION */}
             <Box sx={{ textAlign: 'center' }}>
-              <FantasyButton color="success" onClick={resetVisuals}>{t('validate')}</FantasyButton>
+              <FantasyButton
+                loading={isLoading}
+                color="success"
+                onClick={resetVisuals}
+              >{t('validate')}
+              </FantasyButton>
             </Box>
           </>
         )}

--- a/client/src/views/TournamentView.tsx
+++ b/client/src/views/TournamentView.tsx
@@ -2,7 +2,7 @@ import { Fighter, TournamentsGetDailyResponse } from '@labrute/core';
 import { Close } from '@mui/icons-material';
 import { Box, Paper, useMediaQuery, useTheme } from '@mui/material';
 import moment from 'moment';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import BruteTooltip from '../components/Brute/BruteTooltip';
@@ -37,6 +37,7 @@ const TournamentView = () => {
   const smallScreen = useMediaQuery('(max-width: 935px)');
   const { brute, updateBrute } = useBrute();
   const { palette: { mode } } = useTheme();
+  const [isLoading, setIsLoading] = useState(false);
 
   const tournamentProps = useMemo(() => ({ name: bruteName || '', date: date || '' }), [bruteName, date]);
   const { data: tournament } = useStateAsync(null, Server.Tournament.getDaily, tournamentProps);
@@ -144,7 +145,9 @@ const TournamentView = () => {
   const setWatched = useCallback(async () => {
     if (!brute) return;
 
-    await Server.Tournament.setDailyWatched(brute.name);
+    setIsLoading(true);
+    await Server.Tournament.setDailyWatched(brute.name)
+      .finally(() => setIsLoading(false));
 
     updateBrute((b) => (b ? {
       ...b,
@@ -166,6 +169,7 @@ const TournamentView = () => {
         display={display}
         goToFight={goToFight}
         setWatched={setWatched}
+        isLoading={isLoading}
       />
     ) : (
       <Page title={`${t('tournament')} ${t('MyBrute')}`} headerUrl={`/${bruteName || ''}/cell`}>
@@ -178,7 +182,7 @@ const TournamentView = () => {
         </Paper>
         <Paper sx={{ position: 'relative', bgcolor: 'background.paperLight', mt: -2 }}>
           {ownsBrute && stepWatched < 6 && (
-            <FantasyButton onClick={setWatched} color="success">
+            <FantasyButton onClick={setWatched} color="success" loading={isLoading}>
               {t('setAsWatched')}
             </FantasyButton>
           )}

--- a/client/src/views/VersusView.tsx
+++ b/client/src/views/VersusView.tsx
@@ -134,7 +134,7 @@ const VersusView = () => {
             <Text h5 upperCase bold color="secondary">{t('level')} {opponent.level}</Text>
           </Grid>
         </Grid>
-        <StyledButton onClick={startFight} sx={{ ml: '39.8%' }}>
+        <StyledButton onClick={startFight} sx={{ ml: '39.8%' }} loading={fighting}>
           <Text h5 typo="handwritten" upperCase bold color="secondary">{t('startFight')}</Text>
         </StyledButton>
       </BoxBg>

--- a/client/src/views/clan/ClanPostView.tsx
+++ b/client/src/views/clan/ClanPostView.tsx
@@ -25,6 +25,7 @@ const ClanPostView = () => {
   const [title, setTitle] = useState('');
   const [post, setPost] = useState<ClanGetThreadResponse['posts'][number]>();
   const [content, setContent] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const editing = useMemo(() => location.pathname.endsWith('/edit'), [location.pathname]);
 
   const changeTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -50,21 +51,22 @@ const ClanPostView = () => {
       return;
     }
 
+    setIsLoading(true);
     if (tid === '0') {
       Server.Clan.createThread(bruteName || '', id, title, content).then(() => {
         Alert.open('success', t('threadCreated'));
         navigate(`/${bruteName}/clan/${id}/forum`);
-      }).catch(catchError(Alert));
+      }).catch(catchError(Alert)).finally(() => setIsLoading(false));
     } else if (!editing) {
       Server.Clan.createPost(bruteName || '', tid, content).then(() => {
         Alert.open('success', t('replyPosted'));
         navigate(`/${bruteName}/clan/${id}/thread/${tid}`);
-      }).catch(catchError(Alert));
+      }).catch(catchError(Alert)).finally(() => setIsLoading(false));
     } else if (post && editing) {
       Server.Clan.updateThread(bruteName || '', id, title, content, tid, post.id).then(() => {
         Alert.open('success', t('threadEdited'));
         navigate(`/${bruteName}/clan/${id}/thread/${tid}`);
-      }).catch(catchError(Alert));
+      }).catch(catchError(Alert)).finally(() => setIsLoading(false));
     }
   };
 
@@ -173,7 +175,13 @@ const ClanPostView = () => {
             ],
           }}
         />
-        <FantasyButton color="success" onClick={save} sx={{ mt: 1 }}>{t('send')}</FantasyButton>
+        <FantasyButton
+          loading={isLoading}
+          color="success"
+          onClick={save}
+          sx={{ mt: 1 }}
+        >{t('send')}
+        </FantasyButton>
       </Paper>
     </Page>
   );

--- a/client/src/views/mobile/TournamentMobileView.tsx
+++ b/client/src/views/mobile/TournamentMobileView.tsx
@@ -33,6 +33,7 @@ interface Props {
   display: boolean,
   goToFight: (fight: TournamentsGetDailyResponse['fights'][number], newStep: number) => () => void,
   setWatched: () => void,
+  isLoading?: boolean;
 }
 
 const TournamentMobileView = ({
@@ -46,6 +47,7 @@ const TournamentMobileView = ({
   display,
   goToFight,
   setWatched,
+  isLoading,
 }: Props) => {
   const { t } = useTranslation();
   const { authing } = useAuth();
@@ -62,7 +64,7 @@ const TournamentMobileView = ({
       </Paper>
       <Paper sx={{ bgcolor: 'background.paperLight', mt: -2, }}>
         {ownsBrute && stepWatched < 6 && (
-          <FantasyButton onClick={setWatched} color="success">
+          <FantasyButton onClick={setWatched} color="success" loading={isLoading}>
             {t('setAsWatched')}
           </FantasyButton>
         )}


### PR DESCRIPTION
- Added a loading state of FantasyButton and StyledButton
- Use the loading state for all the CTA that do an API request
- Went through all the user views (did not do Admin views as I assume that is not used by many?)
- Tested all the buttons but let me know if I have missed anything