### PR TITLE
fix: only block current banned fingerprint

### DIFF
--- a/server/src/controllers/OAuth.ts
+++ b/server/src/controllers/OAuth.ts
@@ -18,7 +18,7 @@ import { createUserLog } from '../utils/createUserLog.js';
 import { sendError } from '../utils/sendError.js';
 import { ServerState } from '../utils/ServerState.js';
 import { translate } from '../utils/translate.js';
-import { decryptFPEvent } from '../utils/fingerprint.js';
+import { assertFingerprintAllowed, decryptFPEvent } from '../utils/fingerprint.js';
 import { banUser } from '../utils/user/banUser.js';
 import { DISCORD } from '../context.js';
 
@@ -168,19 +168,6 @@ export class OAuth {
 
       const fingerprint = decryptFPEvent(req.body.eventId);
 
-      // Handle new fingerprints
-      if (!user.fingerprints.includes(fingerprint)) {
-        await this.#prisma.user.update({
-          where: { id: user.id },
-          data: {
-            fingerprints: {
-              push: fingerprint,
-            },
-          },
-        });
-        user.fingerprints.push(fingerprint);
-      }
-
       // Check if user is banned
       if (user.bannedAt) {
         // Revert deletion if the user logs in after deleting their account
@@ -199,11 +186,19 @@ export class OAuth {
         }
       }
 
-      // Check if any of the user fingerprints are banned
-      for (const userFingerprint of user.fingerprints) {
-        if (await ServerState.isFingerprintBanned(this.#prisma, userFingerprint)) {
-          throw new ForbiddenError(translate('fingerprintBanned', user));
-        }
+      await assertFingerprintAllowed(this.#prisma, fingerprint, user);
+
+      // Handle new fingerprints
+      if (!user.fingerprints.includes(fingerprint)) {
+        await this.#prisma.user.update({
+          where: { id: user.id },
+          data: {
+            fingerprints: {
+              push: fingerprint,
+            },
+          },
+        });
+        user.fingerprints.push(fingerprint);
       }
 
       // Check expected headers

--- a/server/src/controllers/Users.ts
+++ b/server/src/controllers/Users.ts
@@ -35,7 +35,7 @@ import { createUserLog } from '../utils/createUserLog.js';
 import { sendError } from '../utils/sendError.js';
 import { translate } from '../utils/translate.js';
 import { banUser } from '../utils/user/banUser.js';
-import { decryptFPEvent } from '../utils/fingerprint.js';
+import { assertFingerprintAllowed, decryptFPEvent } from '../utils/fingerprint.js';
 import { deleteUserBrutes } from '../utils/user/deleteUserBrutes.js';
 
 export const Users = {
@@ -111,6 +111,7 @@ export const Users = {
         }
 
         const fingerprint = decryptFPEvent(req.body.eventId);
+        await assertFingerprintAllowed(prisma, fingerprint, authResult);
 
         if (!authResult.fingerprints.includes(fingerprint)) {
           await prisma.user.update({

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -10,6 +10,7 @@ import { ServerState } from './ServerState.js';
 import { translate } from './translate.js';
 import { banUser } from './user/banUser.js';
 import { DISCORD } from '../context.js';
+import { assertFingerprintAllowed } from './fingerprint.js';
 
 export const auth = async (prisma: PrismaClient, request: Request, options?: {
   admin?: boolean;
@@ -96,13 +97,6 @@ export const auth = async (prisma: PrismaClient, request: Request, options?: {
     throw new ForbiddenError(translate('unauthorized', user));
   }
 
-  // Check if any of the user fingerprints are banned
-  for (const userFingerprint of user.fingerprints) {
-    if (await ServerState.isFingerprintBanned(prisma, userFingerprint)) {
-      throw new ForbiddenError(translate('fingerprintBanned', user));
-    }
-  }
-
   // Check if the sent fingerprint is valid
   // (if the user doesn't have this fingerprint in database,
   // it means it was tampered with, as fingerprints can only
@@ -112,6 +106,8 @@ export const auth = async (prisma: PrismaClient, request: Request, options?: {
     DISCORD().logObject({ userId: user.id, knowns: user.fingerprints, fingerprint }, 'Unrecognized fingerprint detected').catch(() => { /* ignore */ });
     throw new ForbiddenError(translate('banReason.unrecognized_fingerprint', user));
   }
+
+  await assertFingerprintAllowed(prisma, fingerprint, user);
 
   // Check expected headers
   try {

--- a/server/src/utils/fingerprint.ts
+++ b/server/src/utils/fingerprint.ts
@@ -1,11 +1,14 @@
 import {
-  BASE64_ALPHABET, ExpectedError, FINGERPRINT_PRNG, GetFingerprintResponse, OBFUSCATED_ALPHABET,
+  BASE64_ALPHABET, ExpectedError, FINGERPRINT_PRNG, ForbiddenError, GetFingerprintResponse, OBFUSCATED_ALPHABET,
 } from '@labrute/core';
+import { PrismaClient, User } from '@labrute/prisma';
 import crypto from 'crypto';
 import { Request, Response } from 'express';
 import { TLSSocket } from 'tls';
 import { DISCORD, GLOBAL } from '../context.js';
+import { ServerState } from './ServerState.js';
 import { sendError } from './sendError.js';
+import { translate } from './translate.js';
 
 export const readFP = (input: string): Record<string, unknown> => {
   // Step 6: Reverse custom character mapping
@@ -61,6 +64,16 @@ export const decryptFPEvent = (encrypted: string) => {
   let decrypted = decipher.update(encrypted, 'base64', 'utf8');
   decrypted += decipher.final('utf8');
   return decrypted;
+};
+
+export const assertFingerprintAllowed = async (
+  prisma: PrismaClient,
+  fingerprint: string,
+  user?: Pick<User, 'lang'> | null,
+) => {
+  if (await ServerState.isFingerprintBanned(prisma, fingerprint)) {
+    throw new ForbiddenError(translate('fingerprintBanned', user));
+  }
 };
 
 type FingerPrint = {


### PR DESCRIPTION
## Summary\n- Stop rejecting active users because one historical fingerprint is globally banned\n- Check only the current request fingerprint from x-fp or decrypted eventId\n- Keep account bans, IP bans, unknown-fingerprint bans, and header tampering behavior intact\n\n## Verification\n- yarn compile\n\nThis is needed so an active account can recover after another account sharing an old fingerprint was banned.