### PR TITLE
fix: hide daily tournament for event brutes

### DIFF
--- a/client/src/views/mobile/CellMobileView.tsx
+++ b/client/src/views/mobile/CellMobileView.tsx
@@ -159,12 +159,14 @@ export const CellMobileView = ({
             </Tooltip>
           )}
         </Grid>
-        <Grid item xs={12} sm={6} sx={{ textAlign: 'center' }} order={isXs ? 5 : 0}>
-          {/* TOURNAMENT */}
-          <CellTournament
-            language={language}
-          />
-        </Grid>
+        {!brute.eventId && (
+          <Grid item xs={12} sm={6} sx={{ textAlign: 'center' }} order={isXs ? 5 : 0}>
+            {/* TOURNAMENT */}
+            <CellTournament
+              language={language}
+            />
+          </Grid>
+        )}
         <Grid item xs={12} sm={6} sx={{ textAlign: 'center' }} order={isXs ? 6 : 0}>
           {/* GLOBAL TOURNAMENT */}
           <CellGlobalTournament />


### PR DESCRIPTION
## Summary

- hide the daily tournament card for event brutes in the mobile cell view
- match the existing desktop guard while leaving the global tournament card unchanged

Fixes #1409

## Validation

- `pnpm compile`
- `pnpm exec eslint client/src/views/mobile/CellMobileView.tsx`
- `pnpm build:client`